### PR TITLE
fix log likelihood with near-singular covariance

### DIFF
--- a/tests/fusion/test_covariance.py
+++ b/tests/fusion/test_covariance.py
@@ -11,6 +11,11 @@ import numpy as np
 __test_target__ = 'delphi.nowcast.fusion.covariance'
 
 
+def is_posdef(X):
+  """Return whether the given matrix is positive definite."""
+  return np.min(np.linalg.eigvals(X)) > 0
+
+
 class UnitTests(unittest.TestCase):
   """Basic unit tests."""
 
@@ -35,20 +40,6 @@ class UnitTests(unittest.TestCase):
     # numerator and denominator are symmetric
     self.assertTrue(np.allclose(cov2n, cov2n.T))
     self.assertTrue(np.allclose(cov2d, cov2d.T))
-
-  def test_is_posdef(self):
-    self.assertTrue(is_posdef(np.array([
-      [1, 0],
-      [0, 1],
-    ])))
-    self.assertFalse(is_posdef(np.array([
-      [1, 0],
-      [0, -1],
-    ])))
-    self.assertFalse(is_posdef(np.array([
-      [1, 2],
-      [2, 1],
-    ])))
 
   def test_log_likelihood(self):
     cov = np.eye(3)


### PR DESCRIPTION
- switching from "ask permission" to "ask forgiveness", which is safer 
and more pythonic
- old approach checks positive definiteness (via cholesky decomposition) 
before computing log likelihood
- new version attempts to compute log likelihood unconditionally, and 
handles the case when that fails (i.e. non positive definite)
- this is actually faster because scipy internally does its own checking 
for positive definiteness, so checking prior to the call is redundant
- critically, scipy can (and does) determine that a matrix isn't 
positive definite **enough** (through some function on the eigenvalues), 
and so a near-singular but technically positive definite matrix could 
cause the log likelihood call to fail
- now the log likelihood function is robust to all flavors of 
definiteness

> ✔ All 80 tests passed!